### PR TITLE
Support proposed kid:N markers in cache manager reports

### DIFF
--- a/overlord.pl
+++ b/overlord.pl
@@ -392,7 +392,7 @@ sub squidHasAllKids
     # disker strand (mtFindStrand). Is there a mgr page reflecting that state?
     my $mgrPage = &getCacheManagerResponse('openfd_objects')->{content};
     # how many kids completed their per-kid reports
-    my $kidsRegistered = () = $mgrPage =~ /^([}] by kid\d+|\s+kid: \d+)/mg;
+    my $kidsRegistered = () = $mgrPage =~ /^([}] by kid\d+|...\s+#\s+kid: \d+)/mg;
 
     return 1 if !$kidsExpected && !$kidsRegistered; # no-SMP
 

--- a/overlord.pl
+++ b/overlord.pl
@@ -392,7 +392,7 @@ sub squidHasAllKids
     # disker strand (mtFindStrand). Is there a mgr page reflecting that state?
     my $mgrPage = &getCacheManagerResponse('openfd_objects')->{content};
     # how many kids completed their per-kid reports
-    my $kidsRegistered = () = $mgrPage =~ /^([}] by kid\d+|...\s+#\s+kid: \d+)/mg;
+    my $kidsRegistered = () = $mgrPage =~ /^([}] by kid\d+|\.\.\.)/mg;
 
     return 1 if !$kidsExpected && !$kidsRegistered; # no-SMP
 

--- a/overlord.pl
+++ b/overlord.pl
@@ -391,8 +391,8 @@ sub squidHasAllKids
     # TODO: If there is a disker, we should (also) wait for kids to find the
     # disker strand (mtFindStrand). Is there a mgr page reflecting that state?
     my $mgrPage = &getCacheManagerResponse('openfd_objects')->{content};
-    # how many kids completed their by kidN {...} by kidN reports
-    my $kidsRegistered = () = $mgrPage =~ /^[}] by kid\d+/mg;
+    # how many kids completed their per-kid reports
+    my $kidsRegistered = () = $mgrPage =~ /^([}] by kid\d+|\s+kid: \d+)/mg;
 
     return 1 if !$kidsExpected && !$kidsRegistered; # no-SMP
 

--- a/overlord.pl
+++ b/overlord.pl
@@ -392,7 +392,7 @@ sub squidHasAllKids
     # disker strand (mtFindStrand). Is there a mgr page reflecting that state?
     my $mgrPage = &getCacheManagerResponse('openfd_objects')->{content};
     # how many kids completed their per-kid reports
-    my $kidsRegistered = () = $mgrPage =~ /^([}] by kid\d+|\.\.\.)/mg;
+    my $kidsRegistered = () = $mgrPage =~ /^([}] by kid\d+|[.]{3})/mg;
 
     return 1 if !$kidsExpected && !$kidsRegistered; # no-SMP
 


### PR DESCRIPTION
Add support for SMP cache manager report format currently proposed at
https://github.com/squid-cache/squid/pull/1784